### PR TITLE
Remove package-diff.json

### DIFF
--- a/package-diff.js
+++ b/package-diff.js
@@ -1,7 +1,0 @@
-{
-  "devDependencies": {    
-    "ember-cli-shims": "^1.0.2",
-    "ember-source": "^2.11.0",
-    "ember-welcome-page": "^2.0.2",
-  },
-}


### PR DESCRIPTION
This file was there to show the difference between `ember-new`
and `ember-template`'s `package.json` files that I wasn't sure should be
removed, but after looking again, I don't think we need any of these
as they are relics of `ember-new` that aren't necessary in our template.